### PR TITLE
Added JUnit tests for MovieRepository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
             <version>5.13.0-RC1</version>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
     <build>
         <plugins>

--- a/src/test/java/org/example/movieapp/repo/MovieRepositoryTest.java
+++ b/src/test/java/org/example/movieapp/repo/MovieRepositoryTest.java
@@ -1,0 +1,95 @@
+package org.example.movieapp.repo;
+
+import org.example.movieapp.model.Movie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.List;
+import java.util.UUID;
+
+public class MovieRepositoryTest {
+    private MovieRepository repo;
+    private Movie inception;
+    private Movie matrix;
+
+    @BeforeEach
+    void setUp() {
+        repo = new MovieRepository();
+
+        inception = new Movie(
+                "Inception",
+                "Christopher Nolan",
+                2010,
+                148,
+                List.of("Sci-Fi", "Thriller"),
+                8.8
+        );
+
+        matrix = new Movie(
+                "The Matrix",
+                "The Wachowskis",
+                1999,
+                136,
+                List.of("Sci-Fi", "Action"),
+                8.7
+        );
+    }
+
+    @Test
+    void findAndAddById(){
+        repo.add(matrix);
+        Movie found = repo.findById(matrix.getId());
+        Assertions.assertNotNull(found);
+        Assertions.assertEquals("The Matrix", found.getTitle());
+    }
+
+    @Test
+    void findByIdNotFoundReturnsNull() {
+        Movie notFound = repo.findById(UUID.randomUUID());
+        Assertions.assertNull(notFound);
+    }
+
+    @Test
+    void findByTitle() {
+        repo.add(inception);
+        repo.add(matrix);
+
+        Movie found = repo.findByTitle("The Matrix");
+        Assertions.assertNotNull(found);
+        Assertions.assertEquals(matrix.getId(), found.getId());
+    }
+
+    @Test
+    void findAllReturnsListInOrder() {
+        repo.add(inception);
+        repo.add(matrix);
+
+        List<Movie> all = repo.findAll();
+        Assertions.assertEquals(2, all.size());
+        Assertions.assertEquals("Inception", all.get(0).getTitle());
+        Assertions.assertEquals("The Matrix", all.get(1).getTitle());
+    }
+
+    @Test
+    void deleteByIdRemovesMovie() {
+        repo.add(inception);
+        UUID id = inception.getId();
+
+        boolean removed = repo.delete(id);
+        Assertions.assertTrue(removed);
+        Assertions.assertNull(repo.findById(id));
+    }
+
+    @Test
+    void deleteByIdNotFoundReturnsFalse() {
+        boolean removed = repo.delete(UUID.randomUUID());
+        Assertions.assertFalse(removed);
+    }
+
+    @Test
+    void addNullThrowsException() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> repo.add(null));
+    }
+
+}


### PR DESCRIPTION
This pull request introduces a new test suite for the `MovieRepository` class. The test suite ensures comprehensive coverage of repository methods

### Test Suite for `MovieRepository`:

* [`src/test/java/org/example/movieapp/repo/MovieRepositoryTest.java`](diffhunk://#diff-d440e1dd6fb6079a3a943519cf9f6e1e8549b5d8bb21c111611e91736c88d0ecR1-R95): Added a new test class, `MovieRepositoryTest`, with multiple test methods to validate the functionality of `MovieRepository`. Tests include adding, finding, deleting movies, handling null inputs, and verifying the order of returned movie lists.
